### PR TITLE
Clean automation script for picoscope self test

### DIFF
--- a/automation/picoscope_self_test.py
+++ b/automation/picoscope_self_test.py
@@ -1,4 +1,3 @@
-@'
 # pico_5544D_self_test.py — PicoScope 5000D (ps5000a API) self-test
 # - Prints ALL available PICO_STATUS keys (no hard-coded lookups)
 # - Opens unit, prints identity, capabilities, fastest Δt, deep memory
@@ -165,4 +164,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-'@ | Set-Content -Encoding UTF8 automation\picoscope_self_test.py


### PR DESCRIPTION
## Summary
- remove leftover PowerShell wrapper lines from `automation/picoscope_self_test.py`
- ensure the script starts with a comment and ends with a proper `__main__` guard

## Testing
- `python automation/picoscope_self_test.py` *(fails: PicoSDK (ps5000a) not found, check LD_LIBRARY_PATH)*
- `pytest` *(fails: PicoSDK libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a811cbb88322a0c5e326d702360f