### PR TITLE
Fix ps5000aGetTimebase2 call in self-test

### DIFF
--- a/automation/picoscope_self_test.py
+++ b/automation/picoscope_self_test.py
@@ -111,9 +111,9 @@ def fastest_dt_ns(handle, samples=1024):
     """Scan timebase upward to find minimum Δt (ns) for current config."""
     tb = 0
     dt_ns = ctypes.c_float()
-    retmax = ctypes.c_uint32()
+    retmax = ctypes.c_int32()
     while tb < 10000:
-        st = ps.ps5000aGetTimebase2(handle, tb, samples, ctypes.byref(dt_ns), 1, ctypes.byref(retmax), 0)
+        st = ps.ps5000aGetTimebase2(handle, tb, samples, ctypes.byref(dt_ns), ctypes.byref(retmax), 0)
         if st == 0:
             return float(dt_ns.value), tb
         tb += 1


### PR DESCRIPTION
## Summary
- fix ps5000aGetTimebase2 call to match six-argument API
- align retmax buffer type with ps5000aGetTimebase2 signature

## Testing
- `PYTHONPATH=. python automation/picoscope_self_test.py` *(fails: PicoSDK (ps5000a) not found)*
- `PYTHONPATH=. pytest` *(fails: PicoSDK libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44fc9d7a08322974b372e84e93017