### PR TITLE
Reduce CPU usage in single-shot capture loop

### DIFF
--- a/automation/test_ps5000a_single_shot.py
+++ b/automation/test_ps5000a_single_shot.py
@@ -2,6 +2,7 @@ import csv
 import ctypes
 import numpy as np
 import yaml
+import time
 from picosdk.ps5000a import ps5000a as ps
 from picosdk.functions import adc2mV, assert_pico_ok, mV2adc
 
@@ -57,6 +58,7 @@ ps.ps5000aRunBlock(chandle, pre, post, cfg["timebase"], None, 0, None, None)
 ready = ctypes.c_int16(0)
 while not ready.value:
     ps.ps5000aIsReady(chandle, ctypes.byref(ready))
+    time.sleep(0.01)
 
 # Set buffer and retrieve data
 buffer = (ctypes.c_int16 * cfg["samples"])()


### PR DESCRIPTION
## Summary
- add a brief sleep to single-shot capture wait loop to avoid high CPU usage

## Testing
- `pytest` *(fails: No module named 'picosdk' / PicoSDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4781ca66c832280679b69644af557