### PR TITLE
Ensure ps5000a devices always release

### DIFF
--- a/automation/test_ps5000a_single_shot.py
+++ b/automation/test_ps5000a_single_shot.py
@@ -51,36 +51,37 @@ ps.ps5000aGetTimebase2(
     ctypes.byref(time_interval), ctypes.byref(returned), 0
 )
 
-# Start capture
-ps.ps5000aRunBlock(chandle, pre, post, cfg["timebase"], None, 0, None, None)
+# Start capture and processing
+try:
+    ps.ps5000aRunBlock(chandle, pre, post, cfg["timebase"], None, 0, None, None)
 
-# Wait until ready
-ready = ctypes.c_int16(0)
-while not ready.value:
-    ps.ps5000aIsReady(chandle, ctypes.byref(ready))
-    time.sleep(0.01)
+    # Wait until ready
+    ready = ctypes.c_int16(0)
+    while not ready.value:
+        ps.ps5000aIsReady(chandle, ctypes.byref(ready))
+        time.sleep(0.01)
 
-# Set buffer and retrieve data
-buffer = (ctypes.c_int16 * cfg["samples"])()
-ps.ps5000aSetDataBuffer(chandle, channel, ctypes.byref(buffer), cfg["samples"], 0, 0)
+    # Set buffer and retrieve data
+    buffer = (ctypes.c_int16 * cfg["samples"])()
+    ps.ps5000aSetDataBuffer(chandle, channel, ctypes.byref(buffer), cfg["samples"], 0, 0)
 
-c_samples = ctypes.c_uint32(cfg["samples"])
-overflow = ctypes.c_int16()
-ps.ps5000aGetValues(chandle, 0, ctypes.byref(c_samples), 0, 0, 0, ctypes.byref(overflow))
+    c_samples = ctypes.c_uint32(cfg["samples"])
+    overflow = ctypes.c_int16()
+    ps.ps5000aGetValues(chandle, 0, ctypes.byref(c_samples), 0, 0, 0, ctypes.byref(overflow))
 
-# Convert to physical units
-adc_mv = adc2mV(buffer, vrange, max_adc)
-time_ns = np.linspace(-pre, post - 1, cfg["samples"]) * time_interval.value
+    # Convert to physical units
+    adc_mv = adc2mV(buffer, vrange, max_adc)
+    time_ns = np.linspace(-pre, post - 1, cfg["samples"]) * time_interval.value
 
-# Store CSV in chunks
-chunk = cfg["write_chunk"]
-with open(cfg["csv_path"], "w", newline="") as fh:
-    writer = csv.writer(fh)
-    writer.writerow(["time_ns", "mV"])
-    for i in range(0, cfg["samples"], chunk):
-        for t, v in zip(time_ns[i:i+chunk], adc_mv[i:i+chunk]):
-            writer.writerow([t, v])
-
-# Clean up
-ps.ps5000aStop(chandle)
-ps.ps5000aCloseUnit(chandle)
+    # Store CSV in chunks
+    chunk = cfg["write_chunk"]
+    with open(cfg["csv_path"], "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["time_ns", "mV"])
+        for i in range(0, cfg["samples"], chunk):
+            for t, v in zip(time_ns[i:i+chunk], adc_mv[i:i+chunk]):
+                writer.writerow([t, v])
+finally:
+    # Ensure device is stopped and released
+    ps.ps5000aStop(chandle)
+    ps.ps5000aCloseUnit(chandle)


### PR DESCRIPTION
## Summary
- protect single shot automation test with `try/finally` to always stop and close the scope
- guard ps5000a block example cleanup with `try/finally`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'picosdk'; CannotFindPicoSDKError: PicoSDK (ps2000) not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c47914247c8322890a6ad8eea457c1