### PR TITLE
Check for overflow in single-shot capture

### DIFF
--- a/automation/capture_single_shot.py
+++ b/automation/capture_single_shot.py
@@ -68,6 +68,8 @@ try:
     c_samples = ctypes.c_uint32(cfg["samples"])
     overflow = ctypes.c_int16()
     ps.ps5000aGetValues(chandle, 0, ctypes.byref(c_samples), 0, 0, 0, ctypes.byref(overflow))
+    if overflow.value:
+        raise RuntimeError(f"Overflow detected: {overflow.value}")
 
     # Convert to physical units
     adc_mv = adc2mV(buffer, vrange, max_adc)


### PR DESCRIPTION
## Summary
- raise an error when `ps.ps5000aGetValues` reports overflow in `automation/capture_single_shot.py`

## Testing
- `pytest` *(fails: PicoSDK (ps2000) not found, check LD_LIBRARY_PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c47b2165248322a0df3831039407e4