### PR TITLE
Remove oversample parameter from capture_single_shot

### DIFF
--- a/automation/capture_single_shot.py
+++ b/automation/capture_single_shot.py
@@ -69,9 +69,8 @@ assert_pico_ok(
 )
 print(f"Timebase OK: dt={time_interval_ns.value:.3f} ns, max_samples={max_samples.value}")
 
-# Arm & run (oversample=1)
-oversample = 1
-assert_pico_ok(ps.ps5000aRunBlock(chandle, pre, post, int(cfg["timebase"]), oversample, None, 0, None, None))
+# Arm & run
+assert_pico_ok(ps.ps5000aRunBlock(chandle, pre, post, int(cfg["timebase"]), None, 0, None, None))
 print("Acquiring...")
 ready = ctypes.c_int16(0)
 while not ready.value:


### PR DESCRIPTION
## Summary
- drop oversample variable from capture_single_shot automation script
- update ps5000aRunBlock call to use new 8 argument form

## Testing
- `pytest` *(fails: PicoSDK (ps2000) not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ad2a08c883228e5a6dcb8ac821fb