### PR TITLE
Document fork changes and license notice

### DIFF
--- a/read.me
+++ b/read.me
@@ -1,0 +1,20 @@
+This repository derives from Pico Technology's picosdk-python-wrappers project.
+
+Only the ps5000Examples and ps5000aExamples directories remain in this fork. The following example folders were removed:
+- discontinuedExamples
+- picohrdlExamples
+- picosynthExamples
+- pl1000Examples
+- ps2000Examples
+- ps2000aExamples
+- ps3000EExamples
+- ps3000aExamples
+- ps4000Examples
+- ps4000aExamples
+- ps6000Examples
+- ps6000aExamples
+- pt104Examples
+- usbdrdaqExamples
+- usbtc08Examples
+
+For license information, see the existing LICENSE.md file.


### PR DESCRIPTION
## Summary
- document that this repository derives from Pico Technology's picosdk-python-wrappers
- list example folders removed in this fork
- reference existing LICENSE.md for license details

## Testing
- `pytest` *(fails: PicoSDK (ps2000) not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cae4d3a48322b9b0ac33c25030d6