### PR TITLE
Add multi-shot capture workflow

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -4,9 +4,11 @@ Utility scripts for automating basic captures and checks with a PicoScope 5000A 
 
 ## Contents
 
-- `capture_single_shot.py` – captures a single-channel trace using settings from `capture_config_test.yml` and writes the result to CSV.
+- `capture_single_shot.py` – captures a single-channel trace using settings from `capture_config_test.yml` and writes the result to CSV or NumPy.
+- `capture_multi_shot.py` – repeatedly invokes the single-shot script using settings from `capture_multi.yml`.
 - `picoscope_self_test.py` – queries the connected unit and prints identity, capability and timing information for a quick hardware check.
 - `capture_config_test.yml` – sample configuration used by `capture_single_shot.py`.
+- `capture_multi.yml` – sample configuration for `capture_multi_shot.py`.
 
 ## Requirements
 
@@ -28,4 +30,16 @@ To save output files with a timestamped name of the form
 `M08-D24-H13-M05-S30-U.123.csv` (month-day-hour-minute-second-microseconds), set
 `timestamp_filenames: true` in the configuration. When disabled, the
 `csv_path` and `numpy_path` values are used directly.
+
+Run multiple captures with a rest period between each:
+
+```bash
+cd automation
+python capture_multi_shot.py
+```
+
+`capture_multi.yml` accepts all of the single-shot options plus:
+
+- `captures` – number of captures to perform.
+- `rest_ms` – delay between captures in milliseconds.
 

--- a/automation/capture_multi.yml
+++ b/automation/capture_multi.yml
@@ -1,0 +1,26 @@
+resolution: "PS5000A_DR_8BIT"
+channel: "PS5000A_CHANNEL_A"
+coupling: "PS5000A_DC"
+vrange: "PS5000A_5V"
+offset_v: 0.0
+
+timebase: 0
+samples: 10000000
+pre_ratio: 0.0
+
+trig_enabled: false
+trig_source: "PS5000A_CHANNEL_A"
+trig_level_mV: 500
+trig_direction: "PS5000A_RISING"
+auto_trig_ms: 0
+trig_delay_samples: 0
+
+# save_format accepts: "csv", "numpy", or "both"
+save_format: "both"
+csv_path: "capture_10M_1ns.csv"
+numpy_path: "capture_10M_1ns.npz"
+write_chunk: 200000
+timestamp_filenames: true
+
+captures: 3
+rest_ms: 500

--- a/automation/capture_multi_shot.py
+++ b/automation/capture_multi_shot.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# capture_multi_shot.py — run repeated captures using capture_single_shot
+
+import time
+import yaml
+import capture_single_shot
+
+CFG_PATH = "capture_multi.yml"
+
+def main(cfg: dict) -> None:
+    captures = int(cfg["captures"])
+    rest_ms = float(cfg["rest_ms"])
+    for i in range(captures):
+        capture_single_shot.main(cfg)
+        if i < captures - 1:
+            time.sleep(rest_ms / 1000.0)
+
+
+if __name__ == "__main__":
+    with open(CFG_PATH, "r") as f:
+        cfg = yaml.safe_load(f)
+    main(cfg)

--- a/automation/capture_single_shot.py
+++ b/automation/capture_single_shot.py
@@ -16,156 +16,162 @@ CFG_PATH = "capture_config_test.yml"
 def pico_ok(code: int) -> bool:
     return code == ps.PICO_STATUS["PICO_OK"]
 
-with open(CFG_PATH, "r") as f:
-    cfg = yaml.safe_load(f)
 
-print(f"Loaded config: channel={cfg['channel']} timebase={cfg['timebase']} samples={cfg['samples']}")
+def main(cfg: dict) -> None:
+    print(f"Loaded config: channel={cfg['channel']} timebase={cfg['timebase']} samples={cfg['samples']}")
 
-# ---- Open unit at requested resolution ----
-h = ctypes.c_int16()
-res = ps.PS5000A_DEVICE_RESOLUTION[cfg.get("resolution", "PS5000A_DR_8BIT")]
-st = ps.ps5000aOpenUnit(ctypes.byref(h), None, res)
+    # ---- Open unit at requested resolution ----
+    h = ctypes.c_int16()
+    res = ps.PS5000A_DEVICE_RESOLUTION[cfg.get("resolution", "PS5000A_DR_8BIT")]
+    st = ps.ps5000aOpenUnit(ctypes.byref(h), None, res)
 
-# Handle common power-source prompts (same pattern as Pico examples)
-try:
-    assert_pico_ok(st)
-except Exception:
-    if st in (
-        ps.PICO_STATUS.get("PICO_POWER_SUPPLY_NOT_CONNECTED", 282),
-        ps.PICO_STATUS.get("PICO_USB3_0_DEVICE_NON_USB3_0_PORT", 286),
-    ):
-        assert_pico_ok(ps.ps5000aChangePowerSource(h, st))
-    else:
-        raise
-
-print(f"Opened PS5000A handle: {h.value}")
-
-# ---- Channel A configuration ----
-chan = ps.PS5000A_CHANNEL[cfg["channel"]]
-coup = ps.PS5000A_COUPLING[cfg["coupling"]]
-vrng = ps.PS5000A_RANGE[cfg["vrange"]]
-assert_pico_ok(ps.ps5000aSetChannel(h, chan, 1, coup, vrng, ctypes.c_float(cfg["offset_v"])))
-print("Channel A set.")
-
-# Try to disable other channels to maximize sample rate (ignore INVALID_CHANNEL)
-for ch_key in ("PS5000A_CHANNEL_B", "PS5000A_CHANNEL_C", "PS5000A_CHANNEL_D"):
-    if ch_key in ps.PS5000A_CHANNEL:
-        st = ps.ps5000aSetChannel(h, ps.PS5000A_CHANNEL[ch_key], 0, coup, vrng, ctypes.c_float(0.0))
-        if (ps.PICO_STATUS.get("PICO_INVALID_CHANNEL") is not None) and (st == ps.PICO_STATUS["PICO_INVALID_CHANNEL"]):
-            pass  # not present on your variant → ignore
+    # Handle common power-source prompts (same pattern as Pico examples)
+    try:
+        assert_pico_ok(st)
+    except Exception:
+        if st in (
+            ps.PICO_STATUS.get("PICO_POWER_SUPPLY_NOT_CONNECTED", 282),
+            ps.PICO_STATUS.get("PICO_USB3_0_DEVICE_NON_USB3_0_PORT", 286),
+        ):
+            assert_pico_ok(ps.ps5000aChangePowerSource(h, st))
         else:
-            assert_pico_ok(st)
+            raise
 
-# ---- Max ADC (for conversions) ----
-max_adc = ctypes.c_int16()
-assert_pico_ok(ps.ps5000aMaximumValue(h, ctypes.byref(max_adc)))
+    print(f"Opened PS5000A handle: {h.value}")
 
-# ---- Trigger config ----
-if cfg.get("trig_enabled", False):
-    src = ps.PS5000A_CHANNEL[cfg["trig_source"]]
-    tdir = ps.PS5000A_THRESHOLD_DIRECTION[cfg["trig_direction"]]
-    thr  = int(mV2adc(cfg["trig_level_mV"], vrng, max_adc))
-    assert_pico_ok(ps.ps5000aSetSimpleTrigger(
-        h, 1, src, thr, tdir, int(cfg["trig_delay_samples"]), int(cfg["auto_trig_ms"])
-    ))
-    print("Trigger enabled.")
-else:
-    assert_pico_ok(ps.ps5000aSetSimpleTrigger(
-        h, 0, chan, 0, ps.PS5000A_THRESHOLD_DIRECTION["PS5000A_RISING"], 0, 0
-    ))
-    print("Trigger disabled (immediate).")
+    # ---- Channel A configuration ----
+    chan = ps.PS5000A_CHANNEL[cfg["channel"]]
+    coup = ps.PS5000A_COUPLING[cfg["coupling"]]
+    vrng = ps.PS5000A_RANGE[cfg["vrange"]]
+    assert_pico_ok(ps.ps5000aSetChannel(h, chan, 1, coup, vrng, ctypes.c_float(cfg["offset_v"])))
+    print("Channel A set.")
 
-# ---- Sample counts ----
-total = int(cfg["samples"])
-pre   = int(total * float(cfg["pre_ratio"]))
-post  = total - pre
+    # Try to disable other channels to maximize sample rate (ignore INVALID_CHANNEL)
+    for ch_key in ("PS5000A_CHANNEL_B", "PS5000A_CHANNEL_C", "PS5000A_CHANNEL_D"):
+        if ch_key in ps.PS5000A_CHANNEL:
+            st = ps.ps5000aSetChannel(h, ps.PS5000A_CHANNEL[ch_key], 0, coup, vrng, ctypes.c_float(0.0))
+            if (ps.PICO_STATUS.get("PICO_INVALID_CHANNEL") is not None) and (st == ps.PICO_STATUS["PICO_INVALID_CHANNEL"]):
+                pass  # not present on your variant → ignore
+            else:
+                assert_pico_ok(st)
 
-# ---- Get valid timebase (6-arg ps5000aGetTimebase2) ----
-tb_req = int(cfg["timebase"])
-tb     = tb_req
-dt_ns  = ctypes.c_float()
-retmax = ctypes.c_int32()
+    # ---- Max ADC (for conversions) ----
+    max_adc = ctypes.c_int16()
+    assert_pico_ok(ps.ps5000aMaximumValue(h, ctypes.byref(max_adc)))
 
-while True:
-    st = ps.ps5000aGetTimebase2(h, tb, total, ctypes.byref(dt_ns), ctypes.byref(retmax), 0)
-    if pico_ok(st):
-        break
-    if st == ps.PICO_STATUS.get("PICO_INVALID_TIMEBASE"):
-        tb += 1
-        continue
-    assert_pico_ok(st)
+    # ---- Trigger config ----
+    if cfg.get("trig_enabled", False):
+        src = ps.PS5000A_CHANNEL[cfg["trig_source"]]
+        tdir = ps.PS5000A_THRESHOLD_DIRECTION[cfg["trig_direction"]]
+        thr  = int(mV2adc(cfg["trig_level_mV"], vrng, max_adc))
+        assert_pico_ok(ps.ps5000aSetSimpleTrigger(
+            h, 1, src, thr, tdir, int(cfg["trig_delay_samples"]), int(cfg["auto_trig_ms"])
+        ))
+        print("Trigger enabled.")
+    else:
+        assert_pico_ok(ps.ps5000aSetSimpleTrigger(
+            h, 0, chan, 0, ps.PS5000A_THRESHOLD_DIRECTION["PS5000A_RISING"], 0, 0
+        ))
+        print("Trigger disabled (immediate).")
 
-if tb != tb_req:
-    print(f"Requested timebase={tb_req} not valid for {total} samples; using timebase={tb}")
-print(f"Timebase OK: dt ~ {dt_ns.value:.3f} ns, driver maxSamples={retmax.value}")
+    # ---- Sample counts ----
+    total = int(cfg["samples"])
+    pre   = int(total * float(cfg["pre_ratio"]))
+    post  = total - pre
 
-# ---- Run block ----
-ts_str = ""
-if cfg.get("timestamp_filenames", False):
-    now = datetime.now()
-    ts_str = (
-        f"M{now.month:02d}-D{now.day:02d}-H{now.hour:02d}-"
-        f"M{now.minute:02d}-S{now.second:02d}-U.{now.microsecond // 1000:03d}"
-    )
-assert_pico_ok(ps.ps5000aRunBlock(h, pre, post, tb, None, 0, None, None))
-print("Acquiring...")
-ready = ctypes.c_int16(0)
-while not ready.value:
-    assert_pico_ok(ps.ps5000aIsReady(h, ctypes.byref(ready)))
-    time.sleep(0.005)
+    # ---- Get valid timebase (6-arg ps5000aGetTimebase2) ----
+    tb_req = int(cfg["timebase"])
+    tb     = tb_req
+    dt_ns  = ctypes.c_float()
+    retmax = ctypes.c_int32()
 
-# ---- Buffers & acquisition (SetDataBuffers requires max & min buffers) ----
-buf_max = (ctypes.c_int16 * total)()
-buf_min = (ctypes.c_int16 * total)()   # not used for downsampling here, but required by API
-assert_pico_ok(ps.ps5000aSetDataBuffers(h, chan, ctypes.byref(buf_max), ctypes.byref(buf_min), total, 0, 0))
+    while True:
+        st = ps.ps5000aGetTimebase2(h, tb, total, ctypes.byref(dt_ns), ctypes.byref(retmax), 0)
+        if pico_ok(st):
+            break
+        if st == ps.PICO_STATUS.get("PICO_INVALID_TIMEBASE"):
+            tb += 1
+            continue
+        assert_pico_ok(st)
 
-c_samples = ctypes.c_int32(total)
-overflow  = ctypes.c_int16()
-assert_pico_ok(ps.ps5000aGetValues(h, 0, ctypes.byref(c_samples), 0, 0, 0, ctypes.byref(overflow)))
-ns = int(c_samples.value)
-print(f"Retrieved {ns} samples; overflow={overflow.value}")
+    if tb != tb_req:
+        print(f"Requested timebase={tb_req} not valid for {total} samples; using timebase={tb}")
+    print(f"Timebase OK: dt ~ {dt_ns.value:.3f} ns, driver maxSamples={retmax.value}")
 
-# ---- Convert to mV & build time axis (ns) ----
-mv = adc2mV(buf_max, vrng, max_adc)
-time_ns = (np.arange(ns, dtype=np.int64) - pre) * float(dt_ns.value)
-
-# ---- Output selection ----
-save_fmt = str(cfg.get("save_format", "csv")).strip().lower()
-do_csv   = save_fmt in ("csv", "both")
-do_np    = save_fmt in ("numpy", "both")
-
-if do_csv:
-    chunk = int(cfg.get("write_chunk", 200000))
-    csv_path = cfg.get("csv_path", "capture.csv")
+    # ---- Run block ----
+    ts_str = ""
     if cfg.get("timestamp_filenames", False):
-        csv_dir = os.path.dirname(csv_path)
-        csv_path = os.path.join(csv_dir, f"{ts_str}.csv")
-    with open(csv_path, "w", newline="") as f:
-        w = csv.writer(f)
-        w.writerow(["time_ns", "mV"])
-        for i in range(0, ns, chunk):
-            j = min(i + chunk, ns)
-            w.writerows(zip(time_ns[i:j], mv[i:j]))
-    print(f"CSV: wrote {ns} rows to {csv_path}")
+        now = datetime.now()
+        ts_str = (
+            f"M{now.month:02d}-D{now.day:02d}-H{now.hour:02d}-"
+            f"M{now.minute:02d}-S{now.second:02d}-U.{now.microsecond // 1000:03d}"
+        )
+    assert_pico_ok(ps.ps5000aRunBlock(h, pre, post, tb, None, 0, None, None))
+    print("Acquiring...")
+    ready = ctypes.c_int16(0)
+    while not ready.value:
+        assert_pico_ok(ps.ps5000aIsReady(h, ctypes.byref(ready)))
+        time.sleep(0.005)
 
-if do_np:
-    np_path = cfg.get("numpy_path", "capture.npz")
-    if cfg.get("timestamp_filenames", False):
-        np_dir = os.path.dirname(np_path)
-        np_path = os.path.join(np_dir, f"{ts_str}.npz")
-    # store both arrays + minimal metadata together
-    np.savez(
-        np_path,
-        time_ns=time_ns,
-        mV=np.asarray(mv, dtype=np.int16),   # stored as int16 mV to keep size small
-        dt_ns=float(dt_ns.value),
-        pre_samples=pre,
-        total_samples=ns,
-        vrange=cfg["vrange"],
-        resolution=cfg.get("resolution", "PS5000A_DR_8BIT"),
-    )
-    print(f"NumPy: wrote arrays to {np_path}")
+    # ---- Buffers & acquisition (SetDataBuffers requires max & min buffers) ----
+    buf_max = (ctypes.c_int16 * total)()
+    buf_min = (ctypes.c_int16 * total)()   # not used for downsampling here, but required by API
+    assert_pico_ok(ps.ps5000aSetDataBuffers(h, chan, ctypes.byref(buf_max), ctypes.byref(buf_min), total, 0, 0))
 
-# ---- Teardown ----
-assert_pico_ok(ps.ps5000aStop(h))
-assert_pico_ok(ps.ps5000aCloseUnit(h))
+    c_samples = ctypes.c_int32(total)
+    overflow  = ctypes.c_int16()
+    assert_pico_ok(ps.ps5000aGetValues(h, 0, ctypes.byref(c_samples), 0, 0, 0, ctypes.byref(overflow)))
+    ns = int(c_samples.value)
+    print(f"Retrieved {ns} samples; overflow={overflow.value}")
+
+    # ---- Convert to mV & build time axis (ns) ----
+    mv = adc2mV(buf_max, vrng, max_adc)
+    time_ns = (np.arange(ns, dtype=np.int64) - pre) * float(dt_ns.value)
+
+    # ---- Output selection ----
+    save_fmt = str(cfg.get("save_format", "csv")).strip().lower()
+    do_csv   = save_fmt in ("csv", "both")
+    do_np    = save_fmt in ("numpy", "both")
+
+    if do_csv:
+        chunk = int(cfg.get("write_chunk", 200000))
+        csv_path = cfg.get("csv_path", "capture.csv")
+        if cfg.get("timestamp_filenames", False):
+            csv_dir = os.path.dirname(csv_path)
+            csv_path = os.path.join(csv_dir, f"{ts_str}.csv")
+        with open(csv_path, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["time_ns", "mV"])
+            for i in range(0, ns, chunk):
+                j = min(i + chunk, ns)
+                w.writerows(zip(time_ns[i:j], mv[i:j]))
+        print(f"CSV: wrote {ns} rows to {csv_path}")
+
+    if do_np:
+        np_path = cfg.get("numpy_path", "capture.npz")
+        if cfg.get("timestamp_filenames", False):
+            np_dir = os.path.dirname(np_path)
+            np_path = os.path.join(np_dir, f"{ts_str}.npz")
+        # store both arrays + minimal metadata together
+        np.savez(
+            np_path,
+            time_ns=time_ns,
+            mV=np.asarray(mv, dtype=np.int16),   # stored as int16 mV to keep size small
+            dt_ns=float(dt_ns.value),
+            pre_samples=pre,
+            total_samples=ns,
+            vrange=cfg["vrange"],
+            resolution=cfg.get("resolution", "PS5000A_DR_8BIT"),
+        )
+        print(f"NumPy: wrote arrays to {np_path}")
+
+    # ---- Teardown ----
+    assert_pico_ok(ps.ps5000aStop(h))
+    assert_pico_ok(ps.ps5000aCloseUnit(h))
+
+
+if __name__ == "__main__":
+    with open(CFG_PATH, "r") as f:
+        cfg = yaml.safe_load(f)
+    main(cfg)
+


### PR DESCRIPTION
## Summary
- refactor `capture_single_shot.py` into a callable `main(cfg)`
- add `capture_multi_shot.py` to run repeated captures from YAML config
- document multi-shot capture usage and options

## Testing
- `python -m py_compile automation/capture_single_shot.py automation/capture_multi_shot.py`
- `pytest` *(fails: PicoSDK (ps2000) not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c4f131f37c832280eb5a867ab0c024