### PR TITLE
Add CLI overrides for automation capture scripts

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -24,7 +24,14 @@ cd automation
 python capture_single_shot.py
 ```
 
-`capture_single_shot.py` reads `capture_config_test.yml` by default. Edit the YAML file to change channel, trigger or output options.
+`capture_single_shot.py` reads `capture_config_test.yml` by default. Any option from the YAML file can also be supplied on the
+command line to override the configuration. For example, to capture 2 million samples using timebase 1:
+
+```bash
+python capture_single_shot.py --samples 2000000 --timebase 1
+```
+
+Use `--help` to see all available flags.
 
 To save output files with a timestamped name of the form
 `M08-D24-H13-M05-S30-U.123.csv` (month-day-hour-minute-second-microseconds), set
@@ -38,7 +45,8 @@ cd automation
 python capture_multi_shot.py
 ```
 
-`capture_multi.yml` accepts all of the single-shot options plus:
+`capture_multi_shot.py` accepts the same command-line overrides as the single-shot script and reads `capture_multi.yml` by
+default. The file and flags include all single-shot options plus:
 
 - `captures` – number of captures to perform.
 - `rest_ms` – delay between captures in milliseconds.

--- a/automation/capture_multi_shot.py
+++ b/automation/capture_multi_shot.py
@@ -1,11 +1,23 @@
 # -*- coding: utf-8 -*-
 # capture_multi_shot.py — run repeated captures using capture_single_shot
+# Reads settings from YAML and allows command-line overrides
 
+import argparse
 import time
 import yaml
+
 import capture_single_shot
 
 CFG_PATH = "capture_multi.yml"
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    """Argument parser covering multi-shot and single-shot options."""
+    p = capture_single_shot.build_argparser()
+    p.set_defaults(config=CFG_PATH)
+    p.add_argument("--captures", type=int)
+    p.add_argument("--rest-ms", type=float, dest="rest_ms")
+    return p
 
 def main(cfg: dict) -> None:
     captures = int(cfg["captures"])
@@ -17,6 +29,9 @@ def main(cfg: dict) -> None:
 
 
 if __name__ == "__main__":
-    with open(CFG_PATH, "r") as f:
+    parser = build_argparser()
+    args = parser.parse_args()
+    with open(args.config, "r") as f:
         cfg = yaml.safe_load(f)
+    cfg = capture_single_shot.apply_overrides(cfg, args)
     main(cfg)


### PR DESCRIPTION
## Summary
- allow overriding YAML capture options with command-line flags in single and multi-shot scripts
- share argument parser between scripts and document new flags

## Testing
- `pytest` *(fails: PicoSDK (ps2000/ps5000a) not found)*
- `python -m py_compile automation/capture_single_shot.py automation/capture_multi_shot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5c558131c83229a35a43038d84caa