### PR TITLE
feat: allow breaking multi capture on key press

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -50,4 +50,5 @@ default. The file and flags include all single-shot options plus:
 
 - `captures` – number of captures to perform.
 - `rest_ms` – delay between captures in milliseconds.
+- `break_on_key` – stop the loop early if a key is pressed during the rest period.
 

--- a/automation/capture_multi.yml
+++ b/automation/capture_multi.yml
@@ -24,3 +24,4 @@ timestamp_filenames: true
 
 captures: 3
 rest_ms: 500
+break_on_key: false

--- a/automation/capture_multi_shot.py
+++ b/automation/capture_multi_shot.py
@@ -3,10 +3,17 @@
 # Reads settings from YAML and allows command-line overrides
 
 import argparse
+import sys
 import time
 import yaml
 
 import capture_single_shot
+
+try:  # Windows-only module for non-blocking key presses
+    import msvcrt  # type: ignore
+except Exception:  # pragma: no cover - msvcrt is absent on POSIX
+    msvcrt = None  # type: ignore
+    import select
 
 CFG_PATH = "capture_multi.yml"
 
@@ -17,15 +24,49 @@ def build_argparser() -> argparse.ArgumentParser:
     p.set_defaults(config=CFG_PATH)
     p.add_argument("--captures", type=int)
     p.add_argument("--rest-ms", type=float, dest="rest_ms")
+    p.add_argument(
+        "--break-on-key",
+        dest="break_on_key",
+        action="store_true",
+        help="Stop early if a key is pressed during the rest period",
+    )
     return p
+
+
+def _wait_with_break(rest_ms: float, allow_break: bool) -> bool:
+    """Sleep for ``rest_ms`` milliseconds; return True if a key was pressed."""
+    if not allow_break:
+        time.sleep(rest_ms / 1000.0)
+        return False
+
+    print(
+        f"Resting for {rest_ms} ms. Press any key to abort early...",
+        flush=True,
+    )
+    end = time.time() + rest_ms / 1000.0
+    while time.time() < end:
+        if msvcrt:
+            if msvcrt.kbhit():
+                msvcrt.getch()
+                return True
+        else:
+            dr, _, _ = select.select([sys.stdin], [], [], 0)
+            if dr:
+                sys.stdin.readline()
+                return True
+        time.sleep(0.05)
+    return False
 
 def main(cfg: dict) -> None:
     captures = int(cfg["captures"])
     rest_ms = float(cfg["rest_ms"])
+    break_on_key = bool(cfg.get("break_on_key", False))
     for i in range(captures):
         capture_single_shot.main(cfg)
         if i < captures - 1:
-            time.sleep(rest_ms / 1000.0)
+            if _wait_with_break(rest_ms, break_on_key):
+                print("Key pressed — stopping early.")
+                break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `capture_multi_shot.py` to stop early when a key is pressed
- document optional `break_on_key` setting in automation examples

## Testing
- `pytest` *(fails: PicoSDK (ps2000) not found, check LD_LIBRARY_PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d59df7083228b7e4baf2e261ab0